### PR TITLE
check for terminated before trying to stop

### DIFF
--- a/starcluster/node.py
+++ b/starcluster/node.py
@@ -1045,6 +1045,9 @@ class Node(object):
     def is_stopped(self):
         return self.state == "stopped"
 
+    def is_terminated(self):
+        return self.state == "terminated"
+
     def start(self):
         """
         Starts EBS-backed instance and puts it in the 'running' state.
@@ -1134,6 +1137,10 @@ class Node(object):
             log.info(self.alias + " is a spot instance and will "
                      "be terminated.")
             self.terminate()
+            return True
+
+        if self.is_terminated():
+            log.info(self.alias + " is already terminated.")
             return True
 
         self.stop()


### PR DESCRIPTION
```
2018-04-24 08:18:00,593 >>> Still waiting for instances: [<Node: node006 (i-XXXX)>]
2018-04-24 08:18:00,594 >>> statues:[u'terminated']
2018-04-24 08:18:00,609 >>> Stopping node: node006 (i-XXX)
2018-04-24 08:18:00,777 !!! ERROR - IncorrectInstanceState: This instance 'i-XXXX' is not in a state from which it can be stopped.
Traceback (most recent call last):
  File "/home/ubuntu/git/StarCluster/starcluster/cli.py", line 277, in main
    sc.execute(args)
  File "/home/ubuntu/git/StarCluster/starcluster/commands/loadbalance.py", line 161, in execute
    lb.run(cluster)
  File "/home/ubuntu/git/StarCluster/starcluster/balancers/sge/__init__.py", line 673, in run
    n_reboot_restart=self.n_reboot_restart)
  File "/home/ubuntu/git/StarCluster/starcluster/cluster.py", line 2238, in recover
    n_reboot_restart=n_reboot_restart)
  File "/home/ubuntu/git/StarCluster/starcluster/streaming_node_add.py", line 220, in streaming_add
    sna.run()
  File "/home/ubuntu/git/StarCluster/starcluster/streaming_node_add.py", line 190, in run
    self.stream_manage_reboots()
  File "/home/ubuntu/git/StarCluster/starcluster/streaming_node_add.py", line 140, in stream_manage_reboots
    self.instances, dead_instances)
  File "/home/ubuntu/git/StarCluster/starcluster/utils.py", line 663, in filter_move
    return filter(_filter, in_)
  File "/home/ubuntu/git/StarCluster/starcluster/utils.py", line 656, in _filter
    if keep_fct(item):
  File "/home/ubuntu/git/StarCluster/starcluster/streaming_node_add.py", line 139, in <lambda>
    utils.filter_move(lambda i: self.instances_nrm[i.id].check(),
  File "/home/ubuntu/git/StarCluster/starcluster/node.py", line 1402, in check
    return self.handle_reboot()
  File "/home/ubuntu/git/StarCluster/starcluster/node.py", line 1374, in handle_reboot
    terminated = self.node.handle_irresponsive_node()
  File "/home/ubuntu/git/StarCluster/starcluster/node.py", line 1139, in handle_irresponsive_node
    self.stop()
  File "/home/ubuntu/git/StarCluster/starcluster/node.py", line 1076, in stop
    return self.instance.stop()
  File "/home/ubuntu/.virtualenvs/starcluster/local/lib/python2.7/site-packages/boto/ec2/instance.py", line 440, in stop
    rs = self.connection.stop_instances([self.id], force, dry_run=dry_run)
  File "/home/ubuntu/.virtualenvs/starcluster/local/lib/python2.7/site-packages/boto/ec2/connection.py", line 1024, in stop_instances
    [('item', Instance)], verb='POST')
  File "/home/ubuntu/.virtualenvs/starcluster/local/lib/python2.7/site-packages/boto/connection.py", line 1186, in get_list
    raise self.ResponseError(response.status, response.reason, body)
EC2ResponseError: EC2ResponseError: 400 Bad Request
<?xml version="1.0" encoding="UTF-8"?>
<Response><Errors><Error><Code>IncorrectInstanceState</Code><Message>This instance 'i-XXXX' is not in a state from which it can be stopped.</Message></Error></Errors><RequestID>XXX</RequestID></Response>
```